### PR TITLE
corrected length check for the digraph to support utf8 characters

### DIFF
--- a/lua/better-digraphs/init.lua
+++ b/lua/better-digraphs/init.lua
@@ -128,7 +128,7 @@ if vim.g.BetterDigraphsAdditions then
     if string.len(digraph_addition.digraph) ~= 2 then
       error('Digraph ' .. digraph_addition.digraph .. ' should have 2 characters, found ' .. string.len(digraph_addition.digraph))
     end
-    if string.len(digraph_addition.symbol) ~= 1 then
+    if vim.fn.strdisplaywidth(digraph_addition.symbol) ~= 1 then
       error('Digraph symbol ' .. digraph_addition.symbol .. ' should have 1 characters, found ' .. string.len(digraph_addition.symbol))
     end
     default_mapped_by_digraph[digraph_addition.digraph] = {

--- a/lua/better-digraphs/init.lua
+++ b/lua/better-digraphs/init.lua
@@ -129,7 +129,7 @@ if vim.g.BetterDigraphsAdditions then
       error('Digraph ' .. digraph_addition.digraph .. ' should have 2 characters, found ' .. string.len(digraph_addition.digraph))
     end
     if vim.fn.strdisplaywidth(digraph_addition.symbol) ~= 1 then
-      error('Digraph symbol ' .. digraph_addition.symbol .. ' should have 1 characters, found ' .. string.len(digraph_addition.symbol))
+      error('Digraph symbol ' .. digraph_addition.symbol .. ' should have 1 characters, found ' .. vim.fn.strdisplaywidth(digraph_addition.symbol))
     end
     default_mapped_by_digraph[digraph_addition.digraph] = {
       digraph_addition.name,


### PR DESCRIPTION
Hey! 

So basically I had this bug with this config:

```lua
vim.g.BetterDigraphsAdditions = {
  {digraph = "|R", symbol = "ℝ", name = "Real numbers"}, 
}
```

It produced the error: 
```
digraph symbol ℝ should have 1 characters, found 3
```

Which was due to the fact that to check the string length, you used the lua function `string.len` (which checks for the number of **bytes** not **characters**). This fails on multi-bytes characters. 

I corrected it by replacing it with the `vim.fn.strdisplaywidth` function.

Best!