### PR TITLE
README: Move paragraph to proper location and remove duplicate text

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ nnoremap r<C-k><C-k> <Cmd>lua require'better-digraphs'.digraphs("normal")<CR>
 vnoremap r<C-k><C-k> <ESC><Cmd>lua require'better-digraphs'.digraphs("visual")<CR>
 ```
 
+This will allow the usage of the normal `<C-k>` in insert mode, single character replace, and multiple character replace, but allows you to quickly pull up the search if you can't remember the digraph you're looking for. The search will allow you to fuzzy search by either digraph shortcut (OK for ✓) or official name ("CHECK MARK" for ✓).
+
 ## What if I've re-mapped <C-k> to something else
 You can change the command sequence that better digraphs uses to enter digraph mode. (<C-v> is helpful for creating the proper control characters)
 ```lua
@@ -51,27 +53,3 @@ vim.g.BetterDigraphsAdditions = {
   }
 }
 ```
-
-This will allow the usage of the normal `<C-k>` in insert mode, single character replace, and multiple character replace, but allows you to quickly pull up the search if you can't remember the digraph you're looking for. The search will allow you to fuzzy search by either digraph shortcut (OK for ✓) or official name ("CHECK MARK" for ✓).
-
-# Adding or modifying digraphs
-Adding or modifying digraphs can be done by setting the `vim.g.BetterDigraphsAdditions` variable
-
-### Example
-Modifying the `OK` (✓) digraph to be `*`, and adding a new `zz` digraph that maps to `Z`:
-```lua
-vim.g.BetterDigraphsAdditions = {
-  {
-    digraph = "OK",
-    symbol = "*",
-    name = "NEW STAR"
-  },
-  {
-    digraph = "zz",
-    symbol = "Z",
-    name = "CAPITAL Z"
-  }
-}
-```
-
-


### PR DESCRIPTION
Reading the README, it seems a merge might have doubly applied a piece of text